### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,6 +7,10 @@ module.exports = {
   organizationName: 'jeffersonlicet', // Usually your GitHub org/user name.
   projectName: 'React Motion Layout', // Usually your repo name.
   themeConfig: {
+    algolia: {
+      apiKey: '60e4ce389d11f9291daed91bfbb0b51a',
+      indexName: 'azurewebsites_motion-layout',
+    },
     announcementBar: {
       id: 'supportus-new',
       content:


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.